### PR TITLE
Flatten other arguments to gccxml/castxml

### DIFF
--- a/bin/gptrixie
+++ b/bin/gptrixie
@@ -262,11 +262,11 @@ sub do-magic($header, @other) {
 
   my $t = now;
   if $CASTXML {
-    my @arg = '--castxml-gccxml', "-std=$CASTXML_STD", '-o', 'plop.xml', $header, @other;
+    my @arg = '--castxml-gccxml', "-std=$CASTXML_STD", '-o', 'plop.xml', $header, |@other;
     note "Calling castxml : " ~ @arg.join(' ');
     run 'castxml', @arg;
   } else {
-    note "Calling GCCXML : $GCC_XML $header -fxml=plop.xml", @other;
+    note "Calling GCCXML : $GCC_XML $header -fxml=plop.xml", |@other;
     run $GCC_XML,  $header, "-fxml=plop.xml", @other;
   }
   %times<gccxml> = now - $t;


### PR DESCRIPTION
Without this, the call to gccxml/castxml contains a stringified list instead of the list as arguments. While gccxml seems to ignore the superfluous characters, castxml does not and appears not to find specified headers without this.
