### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl"          : "6.*",
     "name"          : "App::GPTrixie",
+    "license"       : "Artistic-2.0",
     "version"       : "*",
     "description"   : "Generate NativeCall code from C headers file",
     "author"        : "Sylvain 'Skarsnik' Colinet <scolinet@gmail.com>",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license