### PR TITLE
Fix for anonymous struct

### DIFF
--- a/bin/gptrixie
+++ b/bin/gptrixie
@@ -296,7 +296,7 @@ sub do-magic($header, @other) {
       }
       when 'Struct' {
         my $s = Struct.new;
-        $s.name = $elem<name>.defined ?? $elem<name> !! $elem<mangled>; #FIXME
+        $s.name = $elem<name>.defined ?? $elem<name> !! $elem<mangled> ?? $elem<mangled> !! 'anon_struct' ~ $elem<id>; #FIXME
         $s.id = $elem<id>;
         $s.set-clocation($elem);
         $s.file = %files{$s.file-id};


### PR DESCRIPTION
It is possible to have an anonymous struct as part of a union like:

```
	typedef struct
	{
	  enum MQTTPropertyCodes identifier; /**<  The MQTT V5 property id. A multi-byte integer. */
	  /** The value of the property, as a union of the different possible types. */
	  union {
	    unsigned char byte;       /**< holds the value of a byte property type */
	    unsigned short integer2;  /**< holds the value of a 2 byte integer property type */
	    unsigned int integer4;    /**< holds the value of a 4 byte integer property type */
	    struct {
	      MQTTLenString data;  /**< The value of a string property, or the name of a user property. */
	      MQTTLenString value; /**< The value of a user property. */
	    };
	  } value;
	} MQTTProperty;
```

(this is the [/usr/include/MQTTProperties.h]( https://github.com/eclipse/paho.mqtt.c/blob/master/src/MQTTProperties.h#L94) from Paho-c)

This tries a bit harder to give the struct a name so it doesn't fail trying to assign Any to the Struct.name just below.

It's probably not the best fix and the generated code may need manual adjustment, but it gets the code generated.